### PR TITLE
refactor: prevent relative path traversal in static file serving

### DIFF
--- a/packages/evershop/src/lib/middlewares/publicStatic.js
+++ b/packages/evershop/src/lib/middlewares/publicStatic.js
@@ -1,5 +1,5 @@
 const fs = require('fs').promises;
-const { join } = require('path');
+const { join, normalize, resolve } = require('path');
 const staticMiddleware = require('serve-static');
 const { CONSTANTS } = require('../helpers');
 
@@ -7,14 +7,21 @@ module.exports = async function publiStatic(request, response, next) {
   // Get the request path
   const { path } = request;
   try {
-    if (!path.includes('.')) {
+    // Sanitize and resolve the requested path to prevent path traversal
+    const baseDir = join(CONSTANTS.ROOTPATH, 'public');
+    const normalizedPath = normalize(path);
+    const resolvedPath = resolve(baseDir, normalizedPath);
+    if (!resolvedPath.startsWith(baseDir)) {
+      throw new Error('Invalid path');
+    }
+    if (!normalizedPath.includes('.')) {
       throw new Error('No file extension');
     }
-    // Asynchoronously check if the path is a file and exists in the public folder
-    const test = await fs.stat(join(CONSTANTS.ROOTPATH, 'public', path));
+    // Asynchronously check if the path is a file and exists in the public folder
+    const test = await fs.stat(resolvedPath);
     if (test.isFile()) {
       // If it is a file, serve it
-      staticMiddleware(join(CONSTANTS.ROOTPATH, 'public'))(
+      staticMiddleware(baseDir)(
         request,
         response,
         next

--- a/packages/evershop/src/lib/middlewares/themePublicStatic.js
+++ b/packages/evershop/src/lib/middlewares/themePublicStatic.js
@@ -1,5 +1,5 @@
 const fs = require('fs').promises;
-const { join } = require('path');
+const { join, normalize } = require('path');
 const staticMiddleware = require('serve-static');
 const { CONSTANTS } = require('../helpers');
 const { getConfig } = require('../util/getConfig');
@@ -7,17 +7,24 @@ const { getConfig } = require('../util/getConfig');
 module.exports = async function themePubliStatic(request, response, next) {
   // Get the request path
   const { path } = request;
+  const normalizedPath = normalize(path);
+
+  // Reject paths that attempt traversal or are absolute
+  if (normalizedPath.startsWith('..') || normalizedPath.startsWith('/')) {
+    return next();
+  }
+
   const theme = getConfig('system.theme', null);
   if (!theme) {
     next();
   } else {
     try {
-      if (!path.includes('.')) {
+      if (!normalizedPath.includes('.')) {
         throw new Error('No file extension');
       }
       // Asynchoronously check if the path is a file and exists in the public folder
       const test = await fs.stat(
-        join(CONSTANTS.THEMEPATH, theme, 'public', path)
+        join(CONSTANTS.THEMEPATH, theme, 'public', normalizedPath)
       );
       if (test.isFile()) {
         // If it is a file, serve it


### PR DESCRIPTION
This PR enhances path sanitization in our static file-serving middleware to mitigate potential relative path traversal vulnerabilities. It adds normalization, resolution, and strict base directory checks before accessing the filesystem.

Changes overview:
- Introduce `normalize` and `resolve` from Node's `path` module to sanitize user-provided paths.
- Define a `baseDir` (e.g., `CONSTANTS.ROOTPATH/public`) and ensure the resolved path remains within this directory.
- Replace direct `join` calls with the sanitized `resolvedPath` for `fs.stat` and `staticMiddleware` invocations.

Bullet-point summary of the fix:  
- Relative Path Traversal: User input was previously concatenated directly into filesystem paths, allowing requests like `../../etc/passwd`. We now normalize the input and resolve it against a known `baseDir`. If the resolved path doesn’t start with `baseDir`, we reject the request. This ensures files outside the public folder cannot be accessed.

Security configuration note:  
- We assume that `CONSTANTS.ROOTPATH` (and similarly `CONSTANTS.THEMEPATH`) correctly point to the absolute root directories for static assets without trailing symlinks. Please review these constants to confirm they don’t introduce unintended traversal. If your deployment uses a different root structure or symbolic links, you may need to adjust `baseDir` accordingly.

> This Autofix was generated by AI. Please review the change before merging.