### PR TITLE
refactor: prevent relative path traversal

### DIFF
--- a/packages/evershop/src/lib/middlewares/publicStatic.js
+++ b/packages/evershop/src/lib/middlewares/publicStatic.js
@@ -1,20 +1,28 @@
 const fs = require('fs').promises;
-const { join } = require('path');
+const { join, normalize, resolve, sep } = require('path');
 const staticMiddleware = require('serve-static');
 const { CONSTANTS } = require('../helpers');
 
 module.exports = async function publiStatic(request, response, next) {
   // Get the request path
-  const { path } = request;
+  const { path: rawPath } = request;
+  // Normalize and validate path to prevent path traversal
+  const normalizedPath = normalize(rawPath);
+  const basePublicPath = resolve(CONSTANTS.ROOTPATH, 'public');
+  const fullPath = resolve(basePublicPath, normalizedPath);
+  // If the requested path is outside the public directory, skip
+  if (!fullPath.startsWith(basePublicPath + sep)) {
+    return next();
+  }
   try {
-    if (!path.includes('.')) {
-      throw new Error('No file extension');
+    if (normalizedPath.includes('..') || !normalizedPath.includes('.')) {
+      throw new Error('Invalid file path');
     }
-    // Asynchoronously check if the path is a file and exists in the public folder
-    const test = await fs.stat(join(CONSTANTS.ROOTPATH, 'public', path));
+    // Asynchronously check if the path is a file and exists in the public folder
+    const test = await fs.stat(fullPath);
     if (test.isFile()) {
       // If it is a file, serve it
-      staticMiddleware(join(CONSTANTS.ROOTPATH, 'public'))(
+      staticMiddleware(basePublicPath)(
         request,
         response,
         next

--- a/packages/evershop/src/lib/middlewares/themePublicStatic.js
+++ b/packages/evershop/src/lib/middlewares/themePublicStatic.js
@@ -1,5 +1,5 @@
 const fs = require('fs').promises;
-const { join } = require('path');
+const { join, normalize } = require('path');
 const staticMiddleware = require('serve-static');
 const { CONSTANTS } = require('../helpers');
 const { getConfig } = require('../util/getConfig');
@@ -7,18 +7,23 @@ const { getConfig } = require('../util/getConfig');
 module.exports = async function themePubliStatic(request, response, next) {
   // Get the request path
   const { path } = request;
+  const normalizedReqPath = normalize(path);
+  if (normalizedReqPath.includes('..') || normalizedReqPath.startsWith('/')) {
+    // Invalid path, possible path traversal
+    next();
+    return;
+  }
   const theme = getConfig('system.theme', null);
   if (!theme) {
     next();
   } else {
     try {
-      if (!path.includes('.')) {
+      if (!normalizedReqPath.includes('.')) {
         throw new Error('No file extension');
       }
-      // Asynchoronously check if the path is a file and exists in the public folder
-      const test = await fs.stat(
-        join(CONSTANTS.THEMEPATH, theme, 'public', path)
-      );
+      // Asynchronously check if the path is a file and exists in the public folder
+      const filePath = join(CONSTANTS.THEMEPATH, theme, 'public', normalizedReqPath);
+      const test = await fs.stat(filePath);
       if (test.isFile()) {
         // If it is a file, serve it
         staticMiddleware(join(CONSTANTS.THEMEPATH, theme, 'public'))(


### PR DESCRIPTION
This PR refactors the static file serving logic to mitigate relative path traversal vulnerabilities by normalizing and strictly validating user-supplied paths before accessing the filesystem.

- Relative Path Traversal: User input could include “..” segments to escape the public directory. We now import and use path.normalize and path.resolve to compute an absolute fullPath under a basePublicPath, then verify it starts with basePublicPath + sep. Requests with invalid segments or missing file extensions are rejected early, and fs.stat is invoked on the sanitized fullPath. The staticMiddleware call has been updated to reference the resolved basePublicPath directly.

Security configuration: We added path normalization and resolution checks to ensure any requested file remains within the intended public directory, effectively blocking path traversal attempts. We assume CONSTANTS.ROOTPATH is correctly set to the application root and that using Node’s path.sep covers both POSIX and Windows separators; please review these assumptions for your deployment environment.

> This Autofix was generated by AI. Please review the change before merging.